### PR TITLE
introduce custom errors

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -36,6 +36,7 @@
     "@graphql-tools/merge": "^8.3.1",
     "@graphql-tools/schema": "^8.5.1",
     "apollo-server-core": "^3.10.0",
+    "apollo-server-errors": "^3.3.1",
     "apollo-server-express": "^3.10.0",
     "cors": "^2.8.5",
     "express": "^4.18.1",

--- a/apps/api/src/lib/custom-errors/not-found.ts
+++ b/apps/api/src/lib/custom-errors/not-found.ts
@@ -1,0 +1,10 @@
+import {ApolloError} from 'apollo-server-errors';
+
+export class NotFoundError extends ApolloError {
+  constructor(
+    message: ApolloError['message'],
+    extensions?: ApolloError['extensions'],
+  ) {
+    super(message, 'NOT_FOUND', extensions);
+  }
+}

--- a/apps/api/src/user/resolver/user.resolver.ts
+++ b/apps/api/src/user/resolver/user.resolver.ts
@@ -1,12 +1,13 @@
 import {GQLResolvers} from '../../generated/graphql.generated';
 import {createUser, getUserById} from '../user.service';
+import {NotFoundError} from '../../lib/custom-errors/not-found';
 
 const resolvers: GQLResolvers = {
   Query: {
     user: async (parent, arguments_) => {
       const user = await getUserById(arguments_.id);
       if (!user) {
-        throw new Error('user not found');
+        throw new NotFoundError('user not found', {id: arguments_.id});
       }
 
       return user;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,7 @@ importers:
       '@typescript-eslint/eslint-plugin': ^5.30.5
       '@typescript-eslint/parser': ^5.30.5
       apollo-server-core: ^3.10.0
+      apollo-server-errors: ^3.3.1
       apollo-server-express: ^3.10.0
       cors: ^2.8.5
       eslint: ^8.0.1
@@ -55,6 +56,7 @@ importers:
       '@graphql-tools/merge': 8.3.1_graphql@16.5.0
       '@graphql-tools/schema': 8.5.1_graphql@16.5.0
       apollo-server-core: 3.10.0_graphql@16.5.0
+      apollo-server-errors: 3.3.1_graphql@16.5.0
       apollo-server-express: 3.10.0_g7snex6epo2tsaz6yhvyva23iq
       cors: 2.8.5
       express: 4.18.1


### PR DESCRIPTION
### What is done?
This PR adds [`apollo-server-errors`](https://www.npmjs.com/package/apollo-server-errors) package and create a `NOT_FOUND` custom error with it.

Use the `NOT_FOUND` custom error in user resolver.

🔐  closes #3 