### PR TITLE
change table and column names to snake case

### DIFF
--- a/apps/api/src/db/knex.ts
+++ b/apps/api/src/db/knex.ts
@@ -1,7 +1,11 @@
+import {knexSnakeCaseMappers} from 'objection';
 import {knex} from 'knex';
 import knexConfig from '../knexfile';
 
 // TODO - differentiate dev, prod and test configs.
-const knexInstance = knex(knexConfig);
+const knexInstance = knex({
+  ...knexConfig,
+  ...knexSnakeCaseMappers(),
+});
 
 export default knexInstance;

--- a/apps/api/src/db/migrations/20220814081959_.ts
+++ b/apps/api/src/db/migrations/20220814081959_.ts
@@ -1,0 +1,19 @@
+import {Knex} from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.alterTable('users', t => {
+    t.renameColumn('firstName', 'first_name');
+    t.renameColumn('lastName', 'last_name');
+    t.renameColumn('createdAt', 'created_at');
+    t.renameColumn('updatedAt', 'updated_at');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.alterTable('users', t => {
+    t.renameColumn('first_name', 'firstName');
+    t.renameColumn('last_name', 'lastName');
+    t.renameColumn('created_at', 'createdAt');
+    t.renameColumn('updated_at', 'updatedAt');
+  });
+}


### PR DESCRIPTION
### What is done?
This PR  adds [`knexSnakeCaseMappers`](https://vincit.github.io/objection.js/api/objection/#knexsnakecasemappers) and adds migration for exisitng `users` table columns (renamed to use `snake_case`).

🔒 closes #4 