### PR TITLE
use UUID instead of incrementing (#12)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,6 +19,7 @@
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",
     "@types/node": "^18.0.3",
+    "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",
     "eslint": "^8.0.1",
@@ -48,6 +49,7 @@
     "joi": "^17.6.0",
     "knex": "^2.2.0",
     "objection": "^3.0.1",
-    "pg": "^8.7.3"
+    "pg": "^8.7.3",
+    "uuid": "^9.0.0"
   }
 }

--- a/apps/api/src/db/migrations/20221002174554_user_use_uuid_as_id_pk.ts
+++ b/apps/api/src/db/migrations/20221002174554_user_use_uuid_as_id_pk.ts
@@ -1,0 +1,19 @@
+import {Knex} from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.alterTable('users', t => {
+    t.dropPrimary();
+    t.uuid('_id').primary();
+    t.dropColumn('id');
+    t.renameColumn('_id', 'id');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.alterTable('users', t => {
+    t.dropPrimary('id');
+    t.increments('_id').primary();
+    t.dropColumn('id');
+    t.renameColumn('_id', 'id');
+  });
+}

--- a/apps/api/src/db/models/common/base.model.ts
+++ b/apps/api/src/db/models/common/base.model.ts
@@ -6,7 +6,7 @@ import {Validator} from 'objection';
 export class BaseModel extends ObjectionModel {
   static idColumn = 'id';
 
-  id: number;
+  id: string;
   createdAt: string;
   updatedAt: string;
 

--- a/apps/api/src/modules/user/graphql/typedefs/schema.graphql
+++ b/apps/api/src/modules/user/graphql/typedefs/schema.graphql
@@ -1,5 +1,5 @@
 type User {
-  id: Int!
+  id: String!
   firstName: String!
   lastName: String!
   email: String!
@@ -9,7 +9,7 @@ type User {
 }
 
 type Query {
-  user(id: Int!): User
+  user(id: String!): User
 }
 
 type Mutation {

--- a/apps/api/src/modules/user/user.model.ts
+++ b/apps/api/src/modules/user/user.model.ts
@@ -3,7 +3,7 @@ import {ModelObject, ToJsonOptions} from 'objection';
 import {BaseModel} from '../../db/models/common/base.model';
 
 export class User extends BaseModel {
-  id: number;
+  id: string;
   firstName: string;
   lastName: string;
   email: string;
@@ -16,7 +16,7 @@ export class User extends BaseModel {
   }
 
   static joiSchema = Joi.object({
-    // `id` isn't needed here because its auto generated.
+    id: Joi.string().uuid({version: 'uuidv4'}),
 
     firstName: Joi.string().min(2).trim().required(),
 

--- a/apps/api/src/modules/user/user.service.ts
+++ b/apps/api/src/modules/user/user.service.ts
@@ -1,4 +1,5 @@
 import bcrypt from 'bcrypt';
+import {v4 as uuidv4} from 'uuid';
 import {User} from './user.model';
 import {config} from '../../lib/config';
 import {GQLUser} from '../../generated/graphql.generated';
@@ -16,6 +17,7 @@ export const createUser = async (user: Omit<GQLUser, 'id'>): Promise<User> => {
   );
 
   return User.query().insertAndFetch({
+    id: uuidv4(),
     firstName: user.firstName,
     lastName: user.lastName,
     email: user.email,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,7 @@ importers:
       '@types/cors': ^2.8.12
       '@types/express': ^4.17.13
       '@types/node': ^18.0.3
+      '@types/uuid': ^8.3.4
       '@typescript-eslint/eslint-plugin': ^5.30.5
       '@typescript-eslint/parser': ^5.30.5
       apollo-server-core: ^3.10.0
@@ -54,6 +55,7 @@ importers:
       ts-node: ^10.9.1
       ts-node-dev: ^2.0.0
       typescript: ^4.6.3
+      uuid: ^9.0.0
     dependencies:
       '@graphql-tools/load-files': 6.6.0_graphql@16.5.0
       '@graphql-tools/merge': 8.3.1_graphql@16.5.0
@@ -71,11 +73,13 @@ importers:
       knex: 2.2.0_pg@8.7.3
       objection: 3.0.1_knex@2.2.0
       pg: 8.7.3
+      uuid: 9.0.0
     devDependencies:
       '@types/bcrypt': 5.0.0
       '@types/cors': 2.8.12
       '@types/express': 4.17.13
       '@types/node': 18.0.3
+      '@types/uuid': 8.3.4
       '@typescript-eslint/eslint-plugin': 5.30.5_6zdoc3rn4mpiddqwhppni2mnnm
       '@typescript-eslint/parser': 5.30.5_4x5o4skxv6sl53vpwefgt23khm
       eslint: 8.19.0
@@ -1814,6 +1818,10 @@ packages:
 
   /@types/strip-json-comments/0.0.30:
     resolution: {integrity: sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==}
+    dev: true
+
+  /@types/uuid/8.3.4:
+    resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
     dev: true
 
   /@types/ws/8.5.3:
@@ -6287,6 +6295,11 @@ packages:
 
   /uuid/8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+    dev: false
+
+  /uuid/9.0.0:
+    resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
     hasBin: true
     dev: false
 


### PR DESCRIPTION
### What is done?

This PR adds `uuid` package and uses it for primary key (`id` column) for `users` table.

- add migration for changing column type to `uuid`
- update graphql user schema to use `string` for `id`
- update user model and base model to use `string` for id and add validation for `uuid`

[🔒]closes #12 