### PR TITLE
feat: add user repository, mappers and DTOs (#19)

### DIFF
--- a/apps/api/.eslintrc.js
+++ b/apps/api/.eslintrc.js
@@ -20,5 +20,6 @@ module.exports = {
   rules: {
     'unicorn/prefer-top-level-await': 'off',
     'unicorn/prefer-module': 'off',
+    'unicorn/no-null': 'off',
   },
 };

--- a/apps/api/src/modules/user/domain/user-created-at.ts
+++ b/apps/api/src/modules/user/domain/user-created-at.ts
@@ -1,0 +1,28 @@
+import {
+  ITimestampProperties,
+  Timestamp,
+} from '../../../shared/domain/value-objects/timestamp';
+
+export interface IUserCreatedAtProperties extends ITimestampProperties {
+  value: undefined | string;
+}
+
+export class UserCreatedAt extends Timestamp<IUserCreatedAtProperties> {
+  get value(): undefined | string {
+    return this.props.value;
+  }
+
+  // eslint-disable-next-line no-useless-constructor
+  private constructor(properties: IUserCreatedAtProperties) {
+    super(properties);
+  }
+
+  public static create(timestamp?: Date) {
+    if (timestamp && !this.isValid(timestamp))
+      throw new Error('Invalid created at timestamp');
+
+    return new UserCreatedAt({
+      value: timestamp ? this.format(timestamp) : undefined,
+    });
+  }
+}

--- a/apps/api/src/modules/user/domain/user-password.ts
+++ b/apps/api/src/modules/user/domain/user-password.ts
@@ -65,7 +65,9 @@ export class UserPassword extends ValueObject<IUserPasswordProperties> {
 
   public static create(properties: IUserPasswordProperties) {
     // TODO - update error messages for all ValueObjects
-    if (!this.isValid(properties.value)) throw new Error('Invalid password');
+    // Do not validate if the password is hashed
+    if (!properties.hashed && !this.isValid(properties.value))
+      throw new Error('Invalid password');
 
     return new UserPassword({
       value: properties.value,

--- a/apps/api/src/modules/user/domain/user-updated-at.ts
+++ b/apps/api/src/modules/user/domain/user-updated-at.ts
@@ -1,0 +1,28 @@
+import {
+  ITimestampProperties,
+  Timestamp,
+} from '../../../shared/domain/value-objects/timestamp';
+
+export interface IUserUpdatedAtProperties extends ITimestampProperties {
+  value: undefined | string;
+}
+
+export class UserUpdatedAt extends Timestamp<IUserUpdatedAtProperties> {
+  get value(): undefined | string {
+    return this.props.value;
+  }
+
+  // eslint-disable-next-line no-useless-constructor
+  private constructor(properties: IUserUpdatedAtProperties) {
+    super(properties);
+  }
+
+  public static create(timestamp?: Date) {
+    if (timestamp && !this.isValid(timestamp))
+      throw new Error('Invalid updated at timestamp');
+
+    return new UserUpdatedAt({
+      value: timestamp ? this.format(timestamp) : undefined,
+    });
+  }
+}

--- a/apps/api/src/modules/user/domain/user.entity.ts
+++ b/apps/api/src/modules/user/domain/user.entity.ts
@@ -5,12 +5,16 @@ import {UserFirstName} from './user-first-name';
 import {UserLastName} from './user-last-name';
 import {UserPassword} from './user-password';
 import {UserId} from './user-id';
+import {UserCreatedAt} from './user-created-at';
+import {UserUpdatedAt} from './user-updated-at';
 
 interface IUserProperties {
   firstName: UserFirstName;
   lastName: UserLastName;
   email: UserEmail;
   password: UserPassword;
+  createdAt?: UserCreatedAt;
+  updatedAt?: UserUpdatedAt;
 }
 
 export class User extends Entity<IUserProperties> {
@@ -34,14 +38,28 @@ export class User extends Entity<IUserProperties> {
     return this.props.password;
   }
 
+  get createdAt() {
+    return this.props.createdAt;
+  }
+
+  get updatedAt() {
+    return this.props.updatedAt;
+  }
+
   // eslint-disable-next-line no-useless-constructor
   private constructor(properties: IUserProperties, id?: EntityID) {
     super(properties, id);
   }
 
-  public static createUser(properties: IUserProperties, id?: EntityID): User {
+  public static create(properties: IUserProperties, id?: EntityID): User {
     // TODO - validation
 
-    return new User(properties, id);
+    return new User(
+      {
+        ...properties,
+        createdAt: properties.createdAt ?? UserCreatedAt.create(new Date()),
+      },
+      id,
+    );
   }
 }

--- a/apps/api/src/modules/user/dtos/user.dto.ts
+++ b/apps/api/src/modules/user/dtos/user.dto.ts
@@ -1,0 +1,9 @@
+export interface IUserDTO {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+  createdAt: null | string;
+  updatedAt: null | string;
+}

--- a/apps/api/src/modules/user/mappers/user.mapper.ts
+++ b/apps/api/src/modules/user/mappers/user.mapper.ts
@@ -1,0 +1,51 @@
+import {UserModel} from '../user.model';
+import {User} from '../domain/user.entity';
+import {UserFirstName} from '../domain/user-first-name';
+import {UserLastName} from '../domain/user-last-name';
+import {UserPassword} from '../domain/user-password';
+import {UserEmail} from '../domain/user-email';
+import {EntityID} from '../../../shared/domain/entity-id';
+import {IUserDTO} from '../dtos/user.dto';
+import {PartialModelObject} from 'objection';
+
+export class UserMapper {
+  public static toDomain(user: UserModel): User {
+    return User.create(
+      {
+        firstName: UserFirstName.create(user.firstName),
+        lastName: UserLastName.create(user.lastName),
+        email: UserEmail.create(user.email),
+        password: UserPassword.create({value: user.password, hashed: true}),
+      },
+      new EntityID(user.id),
+    );
+  }
+
+  public static toDTO(user: User): IUserDTO {
+    return {
+      id: user.userId.id.toString(),
+      firstName: user.firstName.value,
+      lastName: user.lastName.value,
+      email: user.email.value,
+      password: user.password.value,
+      createdAt: user?.createdAt?.value || null,
+      updatedAt: user?.updatedAt?.value || null,
+    };
+  }
+
+  public static async toPersistence(
+    user: User,
+  ): Promise<PartialModelObject<UserModel>> {
+    const password = user.password.isHashed()
+      ? user.password.value
+      : await user.password.getHashedPassword();
+
+    return {
+      id: user.userId.id.toString(),
+      email: user.email.value,
+      firstName: user.firstName.value,
+      lastName: user.lastName.value,
+      password,
+    };
+  }
+}

--- a/apps/api/src/modules/user/repositories/index.ts
+++ b/apps/api/src/modules/user/repositories/index.ts
@@ -1,0 +1,5 @@
+import {UserRepo} from './user.repo';
+
+const userRepo = new UserRepo();
+
+export {userRepo};

--- a/apps/api/src/modules/user/repositories/user.repo.ts
+++ b/apps/api/src/modules/user/repositories/user.repo.ts
@@ -1,0 +1,36 @@
+import {IRepository} from '../../../shared/infra/repository';
+import {User} from '../domain/user.entity';
+import {UserModel} from '../user.model';
+import {UserMapper} from '../mappers/user.mapper';
+
+export class UserRepo implements IRepository<User> {
+  async delete(user: User): Promise<void> {
+    const doesExists = await this.exists(user);
+    if (!doesExists) throw new Error('User does not exist');
+
+    const userId = user.userId.id.toString();
+    await UserModel.query().deleteById(userId);
+  }
+
+  async exists(user: User): Promise<boolean> {
+    const userId = user.userId.id.toString();
+    const foundUser = await UserModel.query().findById(userId);
+
+    return !!foundUser;
+  }
+
+  async save(user: User): Promise<User> {
+    const persistenceUser = await UserMapper.toPersistence(user);
+    const createdUser = await UserModel.query().insertAndFetch(persistenceUser);
+
+    return UserMapper.toDomain(createdUser);
+  }
+
+  async getUserById(id: string): Promise<User> {
+    const user = await UserModel.query().findById(id);
+
+    if (!user) throw new Error('User not found');
+
+    return UserMapper.toDomain(user);
+  }
+}

--- a/apps/api/src/modules/user/user.model.ts
+++ b/apps/api/src/modules/user/user.model.ts
@@ -1,5 +1,4 @@
 import Joi from 'joi';
-import {ModelObject, ToJsonOptions} from 'objection';
 import {BaseModel} from '../../db/models/common/base.model';
 
 export class UserModel extends BaseModel {
@@ -25,19 +24,6 @@ export class UserModel extends BaseModel {
 
     email: Joi.string().email().required(),
   });
-
-  toJSON(opt?: ToJsonOptions): ModelObject<this> {
-    /**
-     * "any" here because:
-     * {@link} https://github.com/Vincit/objection.js/issues/1861
-     */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = super.toJSON(opt) as any;
-
-    delete result.password;
-
-    return result;
-  }
 
   fullName() {
     return `${this.firstName} ${this.lastName}`;

--- a/apps/api/src/modules/user/user.service.ts
+++ b/apps/api/src/modules/user/user.service.ts
@@ -1,34 +1,29 @@
-import {UserModel} from './user.model';
 import {GQLUser} from '../../generated/graphql.generated';
 import {User} from './domain/user.entity';
 import {UserFirstName} from './domain/user-first-name';
 import {UserPassword} from './domain/user-password';
 import {UserLastName} from './domain/user-last-name';
 import {UserEmail} from './domain/user-email';
+import {UserMapper} from './mappers/user.mapper';
+import {userRepo} from './repositories';
+import {IUserDTO} from './dtos/user.dto';
 
-export const getUserById = async (
-  id: GQLUser['id'],
-): Promise<UserModel | undefined> => {
-  return UserModel.query().findById(id);
+export const getUserById = async (id: GQLUser['id']): Promise<IUserDTO> => {
+  const user = await userRepo.getUserById(id);
+  return UserMapper.toDTO(user);
 };
 
 export const createUser = async (
   user: Omit<GQLUser, 'id'>,
-): Promise<UserModel> => {
-  const userData = User.createUser({
+): Promise<IUserDTO> => {
+  const userData = User.create({
     lastName: UserLastName.create(user.lastName),
     firstName: UserFirstName.create(user.firstName),
     email: UserEmail.create(user.email),
     password: UserPassword.create({value: user.password, hashed: false}),
   });
 
-  const hashedPassword = await userData.password.getHashedPassword();
+  const createdUser = await userRepo.save(userData);
 
-  return UserModel.query().insertAndFetch({
-    id: userData.userId.id.toValue(),
-    firstName: userData.firstName.value,
-    lastName: userData.lastName.value,
-    email: userData.email.value,
-    password: hashedPassword,
-  });
+  return UserMapper.toDTO(createdUser);
 };

--- a/apps/api/src/shared/domain/value-objects/timestamp.ts
+++ b/apps/api/src/shared/domain/value-objects/timestamp.ts
@@ -1,0 +1,26 @@
+import Joi from 'joi';
+import {ValueObject} from '../value-object';
+
+export interface ITimestampProperties {
+  value: string | undefined;
+}
+
+export class Timestamp<T extends ITimestampProperties> extends ValueObject<T> {
+  // eslint-disable-next-line no-useless-constructor
+  public constructor(properties: T) {
+    super(properties);
+  }
+
+  protected static isValid(timestamp: Date) {
+    const {error} = Joi.string()
+      .required()
+      .isoDate()
+      .validate(timestamp.toISOString());
+
+    return !error;
+  }
+
+  protected static format(timestamp: Date) {
+    return timestamp.toISOString();
+  }
+}

--- a/apps/api/src/shared/infra/repository.ts
+++ b/apps/api/src/shared/infra/repository.ts
@@ -1,0 +1,5 @@
+export interface IRepository<T> {
+  exists(t: T): Promise<boolean>;
+  delete(t: T): Promise<void>;
+  save(t: T): Promise<T>;
+}


### PR DESCRIPTION
### What is done?

- adds user repository
- adds user mappers
- adds user DTOs
- adds timestamp value object and based on that create user created and updated timestamps
- uses above in user service
- updates user model and remove logic of not returning password

[🐌] makes progress in #16 
[🔒] closes #19 