### PR TITLE
feat: use inversify for DI (#25)

### DIFF
--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -90,7 +90,7 @@ module.exports = {
   // moduleNameMapper: {},
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
-  // modulePathIgnorePatterns: [],
+  modulePathIgnorePatterns: ['./dist'],
 
   // Activates notifications for test results
   // notify: false,
@@ -134,7 +134,7 @@ module.exports = {
   // setupFiles: [],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  // setupFilesAfterEnv: [],
+  setupFilesAfterEnv: ['./src/jest.setup.ts'],
 
   // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -52,6 +52,7 @@
     "graphql": "^16.5.0",
     "graphql-modules": "^2.1.0",
     "helmet": "^5.1.1",
+    "inversify": "^6.0.1",
     "joi": "^17.6.0",
     "knex": "^2.2.0",
     "objection": "^3.0.1",

--- a/apps/api/src/inversify.config.ts
+++ b/apps/api/src/inversify.config.ts
@@ -1,0 +1,14 @@
+import {Container} from 'inversify';
+import {IGlobalIDProvider} from './lib/global-object-id/global-object-id-provider';
+import {GlobalObjectIDService} from './lib/global-object-id/global-object-id.service';
+import {Base64} from './lib/global-object-id/providers/base64';
+import TYPES from './inversify.types';
+
+const container = new Container();
+
+container.bind<IGlobalIDProvider>(TYPES.GlobalIDProvider).to(Base64);
+container
+  .bind<GlobalObjectIDService>(TYPES.GlobalObjectIDService)
+  .to(GlobalObjectIDService);
+
+export default container;

--- a/apps/api/src/inversify.types.ts
+++ b/apps/api/src/inversify.types.ts
@@ -1,0 +1,6 @@
+const TYPES = {
+  GlobalIDProvider: Symbol('GlobalIDProvider'),
+  GlobalObjectIDService: Symbol('GlobalObjectIDService'),
+};
+
+export default TYPES;

--- a/apps/api/src/jest.setup.ts
+++ b/apps/api/src/jest.setup.ts
@@ -1,0 +1,5 @@
+import 'reflect-metadata';
+
+// @link https://github.com/inversify/InversifyJS/issues/997
+import { EventEmitter } from 'node:stream';
+Object.getPrototypeOf(EventEmitter.prototype).constructor = Object;

--- a/apps/api/src/lib/global-object-id/__mocks__/object-id-provider.ts
+++ b/apps/api/src/lib/global-object-id/__mocks__/object-id-provider.ts
@@ -1,0 +1,14 @@
+import { decorate, injectable } from "inversify";
+import { IGlobalIDProvider } from "../global-object-id-provider";
+
+// Create a mock obejctIDProvider - i.e. Base64 etc.
+export const decodeMock = jest.fn().mockImplementation(() => 'Viewer|test');
+export const encodeMock = jest.fn();
+export const MockObjectIDProvider = jest.fn<IGlobalIDProvider, []>().mockImplementation(() => {
+  return {
+    decode: decodeMock,
+    encode: encodeMock,
+  };
+});
+
+decorate(injectable(), MockObjectIDProvider)

--- a/apps/api/src/lib/global-object-id/global-object-id.service.ts
+++ b/apps/api/src/lib/global-object-id/global-object-id.service.ts
@@ -1,10 +1,15 @@
+import {inject, injectable} from 'inversify';
+import TYPES from '../../inversify.types';
 import {IGlobalIDProvider} from './global-object-id-provider';
 
+@injectable()
 export class GlobalObjectIDService {
   private readonly _SEPARATOR = '|';
   private readonly _globalIDService: IGlobalIDProvider;
 
-  public constructor(globalIDEncoder: IGlobalIDProvider) {
+  public constructor(
+    @inject(TYPES.GlobalIDProvider) globalIDEncoder: IGlobalIDProvider,
+  ) {
     this._globalIDService = globalIDEncoder;
   }
 

--- a/apps/api/src/lib/global-object-id/providers/base64.ts
+++ b/apps/api/src/lib/global-object-id/providers/base64.ts
@@ -1,5 +1,7 @@
+import {injectable} from 'inversify';
 import {IGlobalIDProvider} from '../global-object-id-provider';
 
+@injectable()
 export class Base64 implements IGlobalIDProvider {
   encode(plainText: string): string {
     const buff = Buffer.from(plainText, 'utf8');

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -6,7 +6,9 @@
     "moduleResolution": "node",
     "sourceMap": true,
     "outDir": "dist",
-    "lib": ["es2015"],
+    "lib": [
+      "es6"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -14,6 +16,7 @@
     "resolveJsonModule": true,
     "rootDir": "src",
     "strictPropertyInitialization": false,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
   },
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,7 @@ importers:
       graphql: ^16.5.0
       graphql-modules: ^2.1.0
       helmet: ^5.1.1
+      inversify: ^6.0.1
       jest: ^29.2.1
       joi: ^17.6.0
       knex: ^2.2.0
@@ -75,6 +76,7 @@ importers:
       graphql: 16.5.0
       graphql-modules: 2.1.0_graphql@16.5.0
       helmet: 5.1.1
+      inversify: 6.0.1
       joi: 17.6.0
       knex: 2.2.0_pg@8.7.3
       objection: 3.0.1_knex@2.2.0
@@ -4870,6 +4872,10 @@ packages:
     dependencies:
       loose-envify: 1.4.0
     dev: true
+
+  /inversify/6.0.1:
+    resolution: {integrity: sha512-B3ex30927698TJENHR++8FfEaJGqoWOgI6ZY5Ht/nLUsFCwHn6akbwtnUAPCgUepAnTpe2qHxhDNjoKLyz6rgQ==}
+    dev: false
 
   /ipaddr.js/1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}


### PR DESCRIPTION
### What is Done?

This PR adds inversifyjs and uses it for dependency injection.
- add inversifyjs
- use inversify
  - used in `GlobalObjectIDService` and `Base64` (`IGlobalObjectIDProvider`)
- add tests for the same


[:lock:]  closes #25 