### PR TITLE
feat: implement `Node` interface to support relay specs (#24)

### DIFF
--- a/apps/api/src/modules/user/graphql/resolvers/user.resolver.ts
+++ b/apps/api/src/modules/user/graphql/resolvers/user.resolver.ts
@@ -3,8 +3,11 @@ import * as UserService from '../../user.service';
 import {NotFoundError} from '../../../../lib/custom-errors/not-found';
 import {UserMapper} from '../../mappers/user.mapper';
 import {UserID} from '../../domain/user-id';
+import {GQLResolvers} from '../../../../generated/graphql';
+import {globalObjectIDService} from '../../../../lib/global-object-id/global-object-id.service';
+import {TEntityType} from '../../../../shared/domain/types';
 
-const resolvers: UserModule.Resolvers = {
+const resolvers: UserModule.Resolvers & {Node: GQLResolvers['Node']} = {
   Query: {
     me: async (_, arguments_) => {
       const userEntityID = UserID.create(arguments_.id);
@@ -16,12 +19,32 @@ const resolvers: UserModule.Resolvers = {
 
       return UserMapper.toDTO(user);
     },
+    node: async (_, arguments_) => {
+      const [type] = <[TEntityType, string]>(
+        globalObjectIDService.parse(arguments_.id)
+      );
+
+      if (type !== 'Viewer') {
+        throw new Error(`type ${type} is invalid`);
+      }
+
+      const userEntityID = UserID.create(arguments_.id);
+      const user = await UserService.getUserById(userEntityID);
+
+      return UserMapper.toDTO(user);
+    },
   },
   Mutation: {
     registerUser: async (_, {registerUserInput}) => {
       const user = await UserService.createUser(registerUserInput, 'Viewer');
 
       return UserMapper.toDTO(user);
+    },
+  },
+  Node: {
+    __resolveType: ({id}) => {
+      const [type] = globalObjectIDService.parse(id);
+      return type as TEntityType;
     },
   },
 };

--- a/apps/api/src/modules/user/graphql/typedefs/schema.graphql
+++ b/apps/api/src/modules/user/graphql/typedefs/schema.graphql
@@ -1,3 +1,7 @@
+interface Node {
+  id: ID!
+}
+
 interface User {
   firstName: String!
   lastName: String!
@@ -6,7 +10,7 @@ interface User {
   updatedAt: String
 }
 
-type Viewer implements User {
+type Viewer implements Node & User {
   id: ID!
   firstName: String!
   lastName: String!
@@ -33,6 +37,7 @@ type RegisterUserPayload {
 
 type Query {
   me(id: ID!): Viewer
+  node(id: ID!): Node
 }
 
 type Mutation {


### PR DESCRIPTION
### What is done?

This PR implements `Node` interface to support relay server [specs](https://relay.dev/docs/guides/graphql-server-specification/).
- implements `Node` interface
- implement `node` query - `node(id: ID!): Node`

[:lock:] closes #24 